### PR TITLE
Update generate.fsh

### DIFF
--- a/tutorials/forge-hol/scripts/generate.fsh
+++ b/tutorials/forge-hol/scripts/generate.fsh
@@ -305,13 +305,13 @@ cdi-new-decorator --named PurchaseOrderDecorator --delegate org.jboss.forge.hol.
 #  Generates JSF beans and pages  #
 #  #############################  #
 
-scaffold-generate --targets org.jboss.forge.hol.petstore.model.Country ;
-scaffold-generate --targets org.jboss.forge.hol.petstore.model.Customer ;
-scaffold-generate --targets org.jboss.forge.hol.petstore.model.Category ;
-scaffold-generate --targets org.jboss.forge.hol.petstore.model.Product ;
-scaffold-generate --targets org.jboss.forge.hol.petstore.model.Item ;
-scaffold-generate --targets org.jboss.forge.hol.petstore.model.OrderLine ;
-scaffold-generate --targets org.jboss.forge.hol.petstore.model.PurchaseOrder ;
+scaffold-generate --targets org.jboss.forge.hol.petstore.model.Country --provider "Faces" ;
+scaffold-generate --targets org.jboss.forge.hol.petstore.model.Customer --provider "Faces" ;
+scaffold-generate --targets org.jboss.forge.hol.petstore.model.Category --provider "Faces" ;
+scaffold-generate --targets org.jboss.forge.hol.petstore.model.Product --provider "Faces" ;
+scaffold-generate --targets org.jboss.forge.hol.petstore.model.Item --provider "Faces" ;
+scaffold-generate --targets org.jboss.forge.hol.petstore.model.OrderLine --provider "Faces" ;
+scaffold-generate --targets org.jboss.forge.hol.petstore.model.PurchaseOrder --provider "Faces" ;
 
 #  AbstractBean
 #  ############


### PR DESCRIPTION
Using forge 3.3.3: forge is asking for additional information in interactive mode wihtout adding this mandatory parameter.

This change is necessary to make the script run.

(by the way: Unfortunately interactive mode is not working at all neither in eclipse nor in the command line interface using windows 10)